### PR TITLE
Fix body height and footer position on small screens

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -18,7 +18,9 @@ body {
     justify-content: center;
     align-items: center;
 
-    height: 100svh;
+    min-height: max(100svh, 650px);
+
+    position: relative;
 }
 
 main {


### PR DESCRIPTION
I added 'position: absolute;' to the body element to make it the containing block of the footer and made its height more dynamic. Changing 'height' to 'min-height' was unnecessary but it is a best practice.